### PR TITLE
Add Twitter SEO tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ Push to a GitHub repository, making sure the repository is set up with `https://
 Content Management
 ------------------
 
+### SEO
+
+On any page, front matter entries can be used to add social media metadata. For example, on a blog post:
+
+```markdown
+# post-specific fields (other fields also may be used in the post, but also are used for SEO)
+layout: post
+date:   2019-04-04
+carousel: true
+
+# also used as title of card preview on Twitter and Facebook
+title:  "Chia Network Announces 2nd VDF Competition with $100,000 in Total Prize Money"
+
+# thumbnail image (note: must be a full URL, so it has to start with `https://chia.net/...`)
+# note: this defaults to https://chia.net/android-chrome-384x384.png
+# note: test this using https://cards-dev.twitter.com/validator and https://developers.facebook.com/tools/debug/sharing/
+image: https://chia.net/android-chrome-384x384.png
+
+# description of the current page
+# note: this defaults to the first paragraph of the content
+description: "This is a blog post on Chia Network's blog."
+
+# content language
+lang: en
+```
+
 ### Contact Info
 
 Edit `collections/_data/contact.yml` - address, phone number, email, and social media profiles are located here.

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,11 @@ social:
     - https://medium.com/@chia.net
     - https://keybase.io/team/chia_network.public
 google_site_verification: 1234 # TODO: replace this with your actual Webmaster verification code
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: https://chia.net/android-chrome-384x384.png
 
 collections_dir: collections
 collections:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,5 +16,8 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
 
+  {% if page.image %}<meta name="twitter:image" content="{{ page.image }}" />{% endif %}
+  {% if page.title %}<meta name="twitter:title" content="{{ page.title }}">{% endif %}
+  {% if page.excerpt %}<meta name="twitter:description" content="{{ page.excerpt | strip_html | strip_newlines }}">{% endif %}
   {% seo %}
 </head>


### PR DESCRIPTION
Add some missing Twitter-specific tags that show in the card preview.

OpenGraph (Facebook) and other social media platforms should already have these, but Jekyll-SEO-Tag left out some of the Twitter equivalents.

Also, add instructions for customizing this to the README.