### PR TITLE
Add titles and SEO sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site/
 .bundle/
 vendor/
 .DS_Store
+.vscode/

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ This may seem inefficient, but GitHub Pages' Jekyll setup currently has no inter
 ---
 layout: homepage
 lang: fr
+title: Accueil - Chia Network
 ---
 ```
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ plugins:
   - jekyll-seo-tag
 
 # SEO settings
-title: Home - Chia Network
+title: Chia Network
 description: > # this means to ignore newlines until "baseurl:"
   A better blockchain and smart transaction platform which is more decentralized, more efficient, and more secure.
 twitter:

--- a/about/index.md
+++ b/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: en
+title: About - Chia Network
 ---

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: en
+title: Blog - Chia Network
 ---

--- a/cn/about/index.md
+++ b/cn/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: cn
+title: 关于 - Chia Network
 ---

--- a/cn/blog/index.md
+++ b/cn/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: cn
+title: 博客 - Chia Network
 ---

--- a/cn/contact/index.md
+++ b/cn/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: cn
+title: 联系 - Chia Network
 ---

--- a/cn/faq/index.md
+++ b/cn/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: cn
+title: 常问问题 - Chia Network
 ---

--- a/cn/greenpaper/index.md
+++ b/cn/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: cn
+title: 绿皮书 - Chia Network
 ---

--- a/cn/index.md
+++ b/cn/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: cn
+title: 家 - Chia Network
 ---

--- a/cn/news/index.md
+++ b/cn/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: cn
+title: 新闻 - Chia Network
 ---

--- a/cn/releases/index.md
+++ b/cn/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: cn
+title: 发布 - Chia Network
 ---

--- a/contact/index.md
+++ b/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: en
+title: Contact - Chia Network
 ---

--- a/de/about/index.md
+++ b/de/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: de
+title: Über - Chia Network
 ---

--- a/de/blog/index.md
+++ b/de/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: de
+title: Blog - Chia Network
 ---

--- a/de/contact/index.md
+++ b/de/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: de
+title: Kontakt - Chia Network
 ---

--- a/de/faq/index.md
+++ b/de/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: de
+title: FAQ - Chia Network
 ---

--- a/de/greenpaper/index.md
+++ b/de/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: de
+title: Grünes Papier - Chia Network
 ---

--- a/de/index.md
+++ b/de/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: de
+title: Zuhause - Chia Network
 ---

--- a/de/news/index.md
+++ b/de/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: de
+title: Nachrichten - Chia Network
 ---

--- a/de/releases/index.md
+++ b/de/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: de
+title: Veröffentlichungen - Chia Network
 ---

--- a/es/about/index.md
+++ b/es/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: es
+title: Acerca de - Chia Network
 ---

--- a/es/blog/index.md
+++ b/es/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: es
+title: Blog - Chia Network
 ---

--- a/es/contact/index.md
+++ b/es/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: es
+title: Contacto - Chia Network
 ---

--- a/es/faq/index.md
+++ b/es/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: es
+title: Preguntas más frecuentes - Chia Network
 ---

--- a/es/greenpaper/index.md
+++ b/es/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: es
+title: Papel Verde - Chia Network
 ---

--- a/es/index.md
+++ b/es/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: es
+title: Hogar - Chia Network
 ---

--- a/es/news/index.md
+++ b/es/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: es
+title: Noticias - Chia Network
 ---

--- a/es/releases/index.md
+++ b/es/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: es
+title: Lanzamientos - Chia Network
 ---

--- a/faq/index.md
+++ b/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: en
+title: FAQ - Chia Network
 ---

--- a/fr/about/index.md
+++ b/fr/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: fr
+title: Sur - Chia Network
 ---

--- a/fr/blog/index.md
+++ b/fr/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: fr
+title: Blog - Chia Network
 ---

--- a/fr/contact/index.md
+++ b/fr/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: fr
+title: Contact - Chia Network
 ---

--- a/fr/faq/index.md
+++ b/fr/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: fr
+title: FAQ - Chia Network
 ---

--- a/fr/greenpaper/index.md
+++ b/fr/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: fr
+title: Papier Vert - Chia Network
 ---

--- a/fr/index.md
+++ b/fr/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: fr
+title: Accueil - Chia Network
 ---

--- a/fr/news/index.md
+++ b/fr/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: fr
+title: Nouvelles - Chia Network
 ---

--- a/fr/releases/index.md
+++ b/fr/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: fr
+title: Versions - Chia Network
 ---

--- a/greenpaper/index.md
+++ b/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: en
+title: Green Paper - Chia Network
 ---

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: download
 lang: en
+title: Home - Chia Network
 redirect_from:
   - /developer/
 ---

--- a/jp/about/index.md
+++ b/jp/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: jp
+title: 約 - Chia Network
 ---

--- a/jp/blog/index.md
+++ b/jp/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: jp
+title: ブログ - Chia Network
 ---

--- a/jp/contact/index.md
+++ b/jp/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: jp
+title: 連絡先 - Chia Network
 ---

--- a/jp/faq/index.md
+++ b/jp/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: jp
+title: よくある質問 - Chia Network
 ---

--- a/jp/greenpaper/index.md
+++ b/jp/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: jp
+title: グリーンペーパー - Chia Network
 ---

--- a/jp/index.md
+++ b/jp/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: jp
+title: ホーム - Chia Network
 ---

--- a/jp/news/index.md
+++ b/jp/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: jp
+title: ニュース - Chia Network
 ---

--- a/jp/releases/index.md
+++ b/jp/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: jp
+title: リリース - Chia Network
 ---

--- a/news/index.md
+++ b/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: en
+title: News - Chia Network
 ---

--- a/nl/about/index.md
+++ b/nl/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: nl
+title: Over - Chia Network
 ---

--- a/nl/blog/index.md
+++ b/nl/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: nl
+title: Blog - Chia Network
 ---

--- a/nl/contact/index.md
+++ b/nl/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: nl
+title: Contact - Chia Network
 ---

--- a/nl/faq/index.md
+++ b/nl/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: nl
+title: FAQ - Chia Network
 ---

--- a/nl/greenpaper/index.md
+++ b/nl/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: nl
+title: Groen Papier - Chia Network
 ---

--- a/nl/index.md
+++ b/nl/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: nl
+title: Huis - Chia Network
 ---

--- a/nl/news/index.md
+++ b/nl/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: nl
+title: Nieuws - Chia Network
 ---

--- a/nl/releases/index.md
+++ b/nl/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: nl
+title: Releases - Chia Network
 ---

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+---
+---
+Sitemap: {{ site.url }}/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,14 @@
+---
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{% for page in site.pages %}{% if page.lang %}
+<url>{% comment %} the default priority of pages is 0.5, so 0.8 means that the page is especially important (0.9 is used for the english pages since all other pages are translations) {% endcomment %}
+    <loc>{{ site.url }}{{ page.url }}</loc>
+    <priority>{% if page.lang == "en" %}0.9{% else %}0.8{% endif %}</priority>{% if page.date %}
+    <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>{% endif %}
+</url>{% endif %}{% endfor %}{% for page in site.documents %}{% if page.layout %}
+<url>
+    <loc>{{ site.url }}{{ page.url }}</loc>{% if page.date %}
+    <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>{% endif %}
+</url>{% endif %}{% endfor %}
+</urlset>

--- a/sr/about/index.md
+++ b/sr/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: sr
+title: О томе - Chia Network
 ---

--- a/sr/blog/index.md
+++ b/sr/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: sr
+title: Блог - Chia Network
 ---

--- a/sr/contact/index.md
+++ b/sr/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: sr
+title: Контакт - Chia Network
 ---

--- a/sr/faq/index.md
+++ b/sr/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: sr
+title: ФАК - Chia Network
 ---

--- a/sr/greenpaper/index.md
+++ b/sr/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: sr
+title: Зелена књига - Chia Network
 ---

--- a/sr/index.md
+++ b/sr/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: sr
+title: Кућа - Chia Network
 ---

--- a/sr/news/index.md
+++ b/sr/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: sr
+title: Вести - Chia Network
 ---

--- a/sr/releases/index.md
+++ b/sr/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: sr
+title: Издања - Chia Network
 ---

--- a/tr/about/index.md
+++ b/tr/about/index.md
@@ -1,4 +1,5 @@
 ---
 layout: about
 lang: tr
+title: Hakkında - Chia Network
 ---

--- a/tr/blog/index.md
+++ b/tr/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog
 lang: tr
+title: Blog - Chia Network
 ---

--- a/tr/contact/index.md
+++ b/tr/contact/index.md
@@ -1,4 +1,5 @@
 ---
 layout: contact
 lang: tr
+title: İletişim - Chia Network
 ---

--- a/tr/faq/index.md
+++ b/tr/faq/index.md
@@ -1,4 +1,5 @@
 ---
 layout: faq
 lang: tr
+title: SSS - Chia Network
 ---

--- a/tr/greenpaper/index.md
+++ b/tr/greenpaper/index.md
@@ -1,4 +1,5 @@
 ---
 layout: greenpaper
 lang: tr
+title: Yeşil kağıt - Chia Network
 ---

--- a/tr/index.md
+++ b/tr/index.md
@@ -1,4 +1,5 @@
 ---
 layout: download
 lang: tr
+title: Ev - Chia Network
 ---

--- a/tr/news/index.md
+++ b/tr/news/index.md
@@ -1,4 +1,5 @@
 ---
 layout: news
 lang: tr
+title: Haberler - Chia Network
 ---

--- a/tr/releases/index.md
+++ b/tr/releases/index.md
@@ -1,4 +1,5 @@
 ---
 layout: releases
 lang: tr
+title: Salıverme - Chia Network
 ---


### PR DESCRIPTION
@ashadle mentioned earlier that the Google Sitelinks are showing the proof-of-space competition blog post as below:

![image](https://user-images.githubusercontent.com/437196/75398544-f9bef900-58c7-11ea-9a77-e6fea00aeed1.png)

And that it was more desirable to show the blog homepage instead. Although we [can't influence this directly](https://support.google.com/webmasters/answer/47334?hl=en), we may be able to influence this by providing a sitemap that prioritizes non-blog-post pages over blog post pages.

This PR adds such a sitemap. We originally tried jekyll-sitemap, but they no longer provide a way to specify priority, so we wrote a custom template and pointed to it in `robots.txt`.

This PR also adds customized page titles, translated into every supported language. I just used Google Translate for everything except English and French, so be aware that these are machine-generated.