### PR TITLE
Adjust bitfield medium for up to 4 threads

### DIFF
--- a/collections/_posts/2021-02-22-plotting-basics.md
+++ b/collections/_posts/2021-02-22-plotting-basics.md
@@ -65,7 +65,7 @@ RAM requirements are different between bitfield and no bitfield. Bitfield requir
   <tr>
     <td class="tg-102i">Bitfield</td>
     <td class="tg-3k1g">2500</td>
-    <td class="tg-3k1g">3840</td>
+    <td class="tg-3k1g">3400</td>
     <td class="tg-3k1g">6750</td>
   </tr>
   <tr>


### PR DESCRIPTION
tests completed - should give same results as 3840 - 165~ force_qs: 0
good up to 4 threads, 4~ MiB waste
tested under ubuntu, confirmed under windows 10