### PR TITLE
Make email link a "mailto" link

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -69,7 +69,7 @@ en: # English
 
     Many on the Chia team are located in the SF Bay Area but remote is fine as we have people all over the world - Keybase, GitHub, and Zoom are how we work. Geographic restrictions, if any, will be noted in a job specification.
 
-    Please send your resume and cover letter to [jobs@chia.net](jobs@chia.net). Please put the role you are applying for as part of the subject line and include anything additionally required by a specific job posting.
+    Please send your resume and cover letter to [jobs@chia.net](mailto:jobs@chia.net). Please put the role you are applying for as part of the subject line and include anything additionally required by a specific job posting.
   blog_title: "Notes from Chia"
   download_title: "Release Notes"
   download_loading_message: "Loading releases..."


### PR DESCRIPTION
Currently, the link to "jobs@chia.net" on the careers page is a standard link to "jobs@chia.net", which the browser interprets as a relative link to "https://www.chia.net/careers/jobs@chia.net":

![Screen Shot 2021-09-02 at 12 16 30 PM](https://user-images.githubusercontent.com/2570291/131903842-b2d48aee-babc-4e01-965b-29b0e28295d7.png)

Prepending the email address with "mailto" will cause the browser to treat it as an email address instead.