### PR TITLE
udpates due to coloured coin rename

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -22,7 +22,7 @@ en: # English
   homemain_addendum: |
     Released under the open source [Apache License](https://www.apache.org/licenses/LICENSE-2.0).
   homemain_box_title: "Download"
-  homemain_box_section_1: "Blockchain, Chialisp and Coloured coins"
+  homemain_box_section_1: "Blockchain, Chialisp, and Chia Asset Tokens"
   homemain_box_section_2: "Install"
   homemain_box_latest_version: "Latest Version:"
   homemain_chia_blockchain_no_releases: "1.0"

--- a/collections/_posts/2020-04-29-coloured-coins-launch.en.md
+++ b/collections/_posts/2020-04-29-coloured-coins-launch.en.md
@@ -6,6 +6,10 @@ date:   2020-04-29
 author: "[Bram Cohen](https://twitter.com/bramcohen)"
 ---
 
+**Update: The Chia token standard is going to be called CAT1. Read more [here](https://www.chia.net/2021/09/23/chia-token-standard-naming.en.html).**
+
+---
+
 Blockchains should make issuing and using coins and assets easier and more trustworthy than in the analog world, but so far the functionality they provide is limited and hacked on awkwardly.
 
 Today we debut one of Chialisp's most powerful smart transactions - Coloured coins.


### PR DESCRIPTION
- replaced "Coloured coins" on homepage with "Chia Asset Tokens"
- added link referencing new CAT1 post on original coloured coins blog post