### PR TITLE
Rename "Latest Beta" to "Latest Dev"

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -133,8 +133,8 @@ layout: default
             </div>
 
             <div class="download-extra-option soft-shadow">
-                <h3>Latest Beta</h3>
-                <p><em>Note: Beta builds are built on every merge to main and may contain bugs or other issues that are not present in tagged releases</em></p>
+                <h3>Latest Dev</h3>
+                <p><em>Note: Dev builds are built on every merge to main and may contain bugs or other issues that are not present in tagged releases</em></p>
                 <ul>
                     <li><a href="https://download.chia.net/beta/ChiaSetup-latest-beta.exe" target="_blank"> Windows </a></li>
                     <li><a href="https://download.chia.net/beta/Chia-intel_latest_beta.dmg" target="_blank"> macOS Intel </a></li>


### PR DESCRIPTION
since we're starting to use "beta" as a more intentional release (like the 1.3-beta1 release for instance). This should hopefully prevent confusion caused by having multiple "beta" releases on the site