### PR TITLE
Update white paper link and move media links to docs site.

### DIFF
--- a/collections/_faq/08-where-can-i-learn-more-about-the-technical-details-of-your-consensus-algorithm.en.md
+++ b/collections/_faq/08-where-can-i-learn-more-about-the-technical-details-of-your-consensus-algorithm.en.md
@@ -4,14 +4,6 @@ order: 8
 title: "Where can I learn more about the technical details of your consensus algorithm?"
 ---
 
-We have academic papers and presentations that give detail about our new consensus algorithm and blockchain software.
-In 2019 we revealed our [Green Paper](https://www.chia.net/assets/ChiaGreenPaper.pdf) outlining the construction of Proofs of Space and Time and illustrating many of the design choices of Chia.
+Details can be found on our [docs site](https://docs.chia.net/docs/03consensus/consensus_intro "Chia's PoST consensus").
 
-We have updated our consensus algorithm and you can review and comment on our [working document](/assets/Chia-New-Consensus-0.9.pdf).
-
-There is also a [2019 talk from Mariano Sorgente](https://youtu.be/_075bzQPooU) at MIT on how to achieve Nakamoto consensus with Proof of Space and VDFs.
-
-Bram Cohen [presented](https://www.youtube.com/watch?v=2Zlcgt8FVz4) at Stanford on February 2018 on Proofs of Space. Our advisors, Dan Boneh, Benedikt Bünz, and Ben Fisch [published a survey of VDFs](https://eprint.iacr.org/2018/712.pdf) which are the underlying technology of Proof of Time.
-Lipa Long [published an explanation of class groups](https://github.com/Chia-Network/vdf-competition/blob/master/classgroups.pdf) that our [Proofs of Time](https://eprint.iacr.org/2018/627.pdf) is based on. Bram presented [Beyond Hellman’s Time-Memory Trade-Offs with Applications to Proofs of Space](https://www.youtube.com/watch?v=iqxkO7C-cyk) at BPASE '18 in January 2018 based on the [academic paper](https://eprint.iacr.org/2017/893) and these [slides](https://view.publitas.com/chia-network/pbase18slides/page/1) by Hamza Abusalah. Ben Fisch gave a [talk](https://www.youtube.com/watch?v=qUoagL7OZ1k&feature=youtu.be) at BPASE 2018 in January 2018 on Verifiable Delay Functions. Bram [spoke at Blockchain at Berkeley](https://www.facebook.com/BlockchainatBerkeley/videos/2006069823011271/) (which starts about 20:00) in March 2018 with [slides](https://cyber.stanford.edu/sites/g/files/sbiybj9936/f/bramcohen.pdf). Bram gave a [talk at BPASE 2017](https://www.youtube.com/watch?v=aYG0NxoG7yw) in January 2017 on removing waste with Proofs of Space and Time ([slides](https://cyber.stanford.edu/sites/g/files/sbiybj9936/f/bramcohen.pdf)).
-
-Bram gave a [talk](https://www.youtube.com/watch?v=zZaB4hM8SQ4) at SF Bitcoin Devs Seminar about data structures for scaling Bitcoin with [slides](https://view.publitas.com/chia-network/bitcoin_data_structures/) and [Merkle Set code](https://github.com/bramcohen/MerkleSet). Bram gave a [talk](https://www.youtube.com/watch?v=zZaB4hM8SQ4) at SF Bitcoin Devs Seminar about removing waste from cryptocurrencies.
+Additionally, we maintain a list of academic papers and presentations about Chia on our [references page](https://docs.chia.net/docs/15resources/references#chias-technical-specs "References to Chia's technical specs").

--- a/collections/_faq/12-what-is-the-chia-strategic-reserve.en.md
+++ b/collections/_faq/12-what-is-the-chia-strategic-reserve.en.md
@@ -4,6 +4,4 @@ order: 12
 title: "What is the Chia Strategic Reserve?"
 ---
 
-Chia will pre-farm a large supply of coins at network launch to help stabilize and grow the Chia economy through Chia’s novel business plan of lending Chia.
-
-Our [Business Whitepaper](https://www.chia.net/assets/Chia-Business-Whitepaper-2021-02-09-v1.0.pdf) has the details.
+Chia Network Inc created 21 million chia at mainnet launch. This is known as the _Strategic Reserve_. For details on the Company's plans for the Strategic Reserve, see page 20 of the [Business Whitepaper](https://www.chia.net/whitepaper/).


### PR DESCRIPTION
The FAQ was still pointing to the original white paper. I updated this link and am redirecting people to the docs site if they want technical details or references.