### PR TITLE
Add capital.com IPO story

### DIFF
--- a/collections/_news/2022-03-21-capital-com.md
+++ b/collections/_news/2022-03-21-capital-com.md
@@ -1,0 +1,9 @@
+---
+title:  "Chia coin’s company could go public this year"
+weblink: "https://capital.com/chia-coin-s-company-could-go-public-this-year"
+date:   2022-03-21 22:00:00
+thumbnail: "/assets/capital-com.jpg"
+source: capital.com
+jumbotron: false
+---
+Chia Network, the blockchain company behind the cryptocurrency Chia coin (XCH), could go public through an initial public offering (IPO) or merger with a special purpose acquisition company (SPAC) this year, according to Gene Hoffman, the company's president.

--- a/collections/_news/2022-03-21-fox-business.md
+++ b/collections/_news/2022-03-21-fox-business.md
@@ -1,7 +1,7 @@
 ---
 title:  "Crypto is not a sanctions escape for Russia: Chia Network COO"
 weblink: "https://video.foxbusiness.com/v/6301406586001#sp=show-clips"
-date:   2022-03-21
+date:   2022-03-21 18:30:00
 thumbnail: "/assets/fox-business.jpg"
 source: foxbusiness.com
 jumbotron: false


### PR DESCRIPTION
Requires specifying a time for the earlier Fox story.