### PR TITLE
Latest intel dev doesn't use the -intel suffix anymore, since nothing…

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -165,7 +165,7 @@ layout: default
                 <p><em>Note: Dev builds are built on every merge to main and may contain bugs or other issues that are not present in tagged releases</em></p>
                 <ul>
                     <li><a href="https://download.chia.net/latest-dev/ChiaSetup-latest-dev.exe" target="_blank"> Windows </a></li>
-                    <li><a href="https://download.chia.net/latest-dev/Chia-intel_latest_dev.dmg" target="_blank"> macOS Intel </a></li>
+                    <li><a href="https://download.chia.net/latest-dev/Chia_latest_dev.dmg" target="_blank"> macOS Intel </a></li>
                     <li><a href="https://download.chia.net/latest-dev/Chia-arm64_latest_dev.dmg" target="_blank"> macOS M1 </a></li>
                     <li><a href="https://download.chia.net/latest-dev/chia-blockchain_amd64_latest_dev.deb" target="_blank"> Ubuntu/Debian </a></li>
                     <li><a href="https://download.chia.net/latest-dev/chia-blockchain_arm64_latest_dev.deb" target="_blank"> Ubuntu/Debian ARM </a></li>


### PR DESCRIPTION
… else did for intel and it made the matrix job inconsistent